### PR TITLE
add possibility to prefix query with lang ":" params

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Yet another translate-shell plugin for rofi. Borrowed quite a bit of code from [
 rofi -show ts -modi ts
 ```
 
+Type the sentence to translate. By default, translate-shell guesses the language to translate from, and translates it to your system locale.
+
+You can prefix your query with language info:
+
+- `fr:en Bonjour` will translate 'Bonjour' from french to english
+- `:fr Hello` will translate 'Hello' from your locale to french
+- `fr: Nombre` will translate 'Nombre' from french to your locale
+
 ## Advanced Usage
 
 ```bash


### PR DESCRIPTION
:wave: hey, thanks a lot for this, very cool to have a rofi/translate-shell combo via a rofi mode instead of a whole separate script like other projects.

Here is a proposal that fits my usecase, figured it could be useful.

Since the whole input was passed to translate-shell as one param, there was no possibility to give from/to languages info.
This small patch allows us to specify lang now.

I'm not a C developer and I know just checking for ":" in first param is not that error-proof… Just figured I'd let you know!

Cheers,
Manu